### PR TITLE
Fix running integration tests locally on macOS

### DIFF
--- a/image-signer-verifier.sh
+++ b/image-signer-verifier.sh
@@ -14,7 +14,6 @@ docker run \
   -v $HOME/.local/tmp:/tmp \
   -v $HOME/.local/tmp/sigstore:/.sigstore \
   -v $HOME/.aws:/.aws:ro \
-  -v $HOME/.docker/:/.docker \
   -v $PWD/policy:/policy \
   -u $(id -u):$(id -g) \
   --network host \

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -41,7 +41,7 @@ function verify_image () {
       --referrers-dest "$REFERRERS_REPO" \
       --referrers-source "$REFERRERS_REPO" \
       --vsa --kms-key-ref "$AWS_KMS_ARN" \
-      --kms-region "$AWS_REGION" --policy-dir "$POLICY_PATH" --platform "linux/amd64" \
+      --kms-region "$AWS_REGION" --tuf=false --policy-dir "$POLICY_PATH" --platform "linux/amd64" \
       --policy-id "$POLICY_ID"
 }
 
@@ -49,7 +49,7 @@ function verify_image_vsa () {
     echo "Verifying the VSA for $INPUT_IMAGE..."
     ./image-signer-verifier.sh verify -i "$INPUT_IMAGE" \
       --referrers-source "$REFERRERS_REPO" \
-      --policy-dir "$POLICY_PATH" --platform "linux/amd64" \
+      --tuf=false --policy-dir "$POLICY_PATH" --platform "linux/amd64" \
       --policy-id "$VSA_POLICY_ID"
 }
 


### PR DESCRIPTION
Mounting the ~/.docker dir into the container means that the auth
settings in config.json are used. If the user uses docker desktop this
means it will try to invoke the credential helper to get the creds,
which fails as this doesn't exist in the container. We can just remove
this mount as the image we need to pull is public.

Also disable TUF do we don't try to write to ~/.docker/tuf, which is a
good idea anyway as we only want to test the policy in this repo.