### PR TITLE
New provenance policy

### DIFF
--- a/image-signer-verifier.sh
+++ b/image-signer-verifier.sh
@@ -11,7 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-isv_image="docker/image-signer-verifier:0.5.20@sha256:c3017e07df0b5c0f7f50c0f73fef866ce673a780c59c201f1b564f83b5d5fb93"
+
+isv_image="docker/image-signer-verifier:0.6.11@sha256:1da7bf832736db04e9913dc191b1b7e539e1aa317cb2eba5ff277cdf6e26528a"
 #isv_image="isv:latest"
 
 mkdir -p $HOME/.local/tmp/sigstore
@@ -28,6 +29,7 @@ docker run \
   -v $HOME/.local/tmp/sigstore:/.sigstore \
   -v $HOME/.aws:/.aws:ro \
   -v $PWD/policy:/policy \
+  -v $PWD/testdata:/testdata \
   -u $(id -u):$(id -g) \
   --network host \
   $isv_image \

--- a/testdata/busybox_provenance.json
+++ b/testdata/busybox_provenance.json
@@ -1,0 +1,177 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:1.37.0?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:1.37?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:1?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:1.37.0-glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:1.37-glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:1-glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:latest?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:unstable?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/busybox:unstable-glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:1.37.0?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:1.37?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:1?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:1.37.0-glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:1.37-glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:1-glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:latest?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:unstable?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/amd64/busybox:unstable-glibc?platform=linux%2Famd64"
+    },
+    {
+      "digest": {
+        "sha256": "22f27168517de1f58dae0ad51eacf1527e7e7ccc47512d3946f56bdbe913f564"
+      },
+      "name": "pkg:docker/oisupport/staging-amd64:e1dc43214da28419a105a665f994080e83093c6849fe2851344350b8c264afd1?platform=linux%2Famd64"
+    }
+  ],
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://actions.github.io/buildtypes/workflow/v1",
+      "externalParameters": {
+        "inputs": {
+          "bashbrewArch": "amd64",
+          "buildId": "e1dc43214da28419a105a665f994080e83093c6849fe2851344350b8c264afd1",
+          "firstTag": "busybox:1.37.0",
+          "pruneArtifact": "false"
+        },
+        "workflow": {
+          "digest": {
+            "gitCommit": "5c3af85f2c735ea2b689271cb64ff38bcca28bec"
+          },
+          "path": ".github/workflows/build.yml",
+          "ref": "refs/heads/main",
+          "repository": "https://github.com/docker-library/meta"
+        }
+      },
+      "internalParameters": {
+        "github": {
+          "event_name": "workflow_dispatch",
+          "repository_id": "852974745",
+          "repository_owner_id": "5429470",
+          "runner_environment": "github-hosted"
+        }
+      },
+      "resolvedDependencies": [
+        {
+          "digest": {
+            "gitCommit": "5c3af85f2c735ea2b689271cb64ff38bcca28bec"
+          },
+          "uri": "git+https://github.com/docker-library/meta@refs/heads/main"
+        }
+      ]
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://github.com/docker-library/meta/.github/workflows/build.yml@refs/heads/main"
+      },
+      "metadata": {
+        "invocationId": "https://github.com/docker-library/meta/actions/runs/11483263454/attempts/1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Change the DOI policy to verify a `https://slsa.dev/provenance/v1` provenance attestation with a `buildType` of `https://actions.github.io/buildtypes/workflow/v1`.

The steps required to verify this provenance for DOI are detailed in https://github.com/docker/doi-image-policy/blob/main/slsa.md#verifying-expectations-for-doi-builds.

### TODO

- [ ] fix unit tests
- [x] fix integration tests
- [ ] verify all tags in subjects of attestation statement
- [ ] add mapping between keys, SLSA build level, and `builder.id`